### PR TITLE
fix path errors

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -113,10 +113,11 @@ mender-artifact write module-image $(echo "$PACKAGES" | sed -e 's/ / -f /g') $(e
   ${devices} \
   --output-path ${OUTPUT_PATH}/${ARTIFACT_NAME}.mender
 
-if [ -f "${OUTPUT_PATH}/${ARTIFACT_NAME}.mender" ]; then
-  echo "Artifact ${OUTPUT_PATH}/${ARTIFACT_NAME}.mender generated successfully:"
-  mender-artifact read ${OUTPUT_PATH}/${ARTIFACT_NAME}.mender
-  echo "::set-output name=path-to-artifact::${OUTPUT_PATH}/${ARTIFACT_NAME}.mender"
+FILE_PATH=$(echo "${OUTPUT_PATH}/${ARTIFACT_NAME}.mender" | sed s#//*#/#g)
+if [ -f "$FILE_PATH" ]; then
+  echo "Artifact $FILE_PATH generated successfully:"
+  mender-artifact read $FILE_PATH
+  echo "path-to-artifact=$FILE_PATH" >> $GITHUB_OUTPUT
   exit 0
 else
   echo "Artifact generation failed."


### PR DESCRIPTION
- fixed https://github.com/KevinRohn/create-mender-artifact/issues/2
- avoid multiple slashes if output path has an trailing slash